### PR TITLE
Add default value of AUTO_INCREMENT for "users" table

### DIFF
--- a/burrito/models/user_model.py
+++ b/burrito/models/user_model.py
@@ -47,3 +47,6 @@ class Users(BurritoBasicModel):
 
     class Meta:
         depends_on = [Roles, Groups, Faculties]
+        table_settings = [
+            "AUTO_INCREMENT = 1073741824"
+        ]


### PR DESCRIPTION
The value is selected as int_size/2.

MySQL int size is 2,147,483,647. So I hope 1,073,741,824 will be enough for new users and not create collisions with Cabinet IDs. 
